### PR TITLE
added ability to modify the used S3 scheme in URIs

### DIFF
--- a/src/main/scala/jp/ne/opt/redshiftfake/Global.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/Global.scala
@@ -7,5 +7,6 @@ import com.amazonaws.regions.{Regions, Region, RegionUtils}
  */
 object Global {
   def s3Endpoint: String = sys.props.getOrElse("fake.awsS3Endpoint", "s3://")
+  def s3Scheme: String = sys.props.getOrElse("fake.awsS3Scheme", s3Endpoint)
   def region: Region = RegionUtils.getRegion(sys.props.getOrElse("fake.awsRegion", Regions.AP_NORTHEAST_1.getName))
 }

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
@@ -12,7 +12,7 @@ trait BaseParser extends RegexParsers {
 
   val any = """(.|\s)"""
 
-  val s3LocationParser = Global.s3Endpoint ~> """[\w-]+""".r ~ ("/" ~> """[\w/:%#$&?()~.=+-]+""".r).? ^^ {
+  val s3LocationParser = Global.s3Scheme ~> """[\w-]+""".r ~ ("/" ~> """[\w/:%#$&?()~.=+-]+""".r).? ^^ {
     case ~(bucket, prefix) => S3Location(bucket, prefix.getOrElse(""))
   }
 

--- a/src/main/scala/jp/ne/opt/redshiftfake/s3/S3Location.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/s3/S3Location.scala
@@ -7,5 +7,5 @@ import jp.ne.opt.redshiftfake.Global
  */
 case class S3Location(bucket: String, prefix: String) {
   val path = s"$bucket/$prefix"
-  val full = Global.s3Endpoint + path
+  val full = Global.s3Scheme + path
 }

--- a/src/test/scala/jp/ne/opt/redshiftfake/IntegrationTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/IntegrationTest.scala
@@ -28,14 +28,14 @@ class IntegrationTest extends fixture.FlatSpec with H2Sandbox with CIOnly {
     conn.createStatement().execute("insert into foo values(5, true, '2016-11-21')")
 
     conn.createStatement().execute(
-      s"""unload ('select c, count(*), sum(a) from foo where b = true group by c order by c') to '${Global.s3Endpoint}foo/unloaded_'
+      s"""unload ('select c, count(*), sum(a) from foo where b = true group by c order by c') to '${Global.s3Scheme}foo/unloaded_'
           |credentials 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
           |manifest
           |addquotes""".stripMargin
     )
 
     conn.createStatement().execute(
-      s"""copy bar from '${Global.s3Endpoint}foo/unloaded_manifest'
+      s"""copy bar from '${Global.s3Scheme}foo/unloaded_manifest'
           |credentials 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
           |manifest
           |removequotes

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
@@ -8,7 +8,7 @@ class CopyCommandParserTest extends FlatSpec {
   it should "parse minimal COPY command" in {
     val command =
       s"""
-        |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+        |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
         |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY';
         |""".stripMargin
 
@@ -33,16 +33,16 @@ class CopyCommandParserTest extends FlatSpec {
   it should "parse JSON format" in {
     val command =
       s"""
-        |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+        |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
         |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
         |JSON;
         |""".stripMargin
 
     val commandWithJsonpath =
       s"""
-        |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+        |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
         |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
-        |JSON '${Global.s3Endpoint}some-bucket/path/to/jsonpaths.txt';
+        |JSON '${Global.s3Scheme}some-bucket/path/to/jsonpaths.txt';
         |""".stripMargin
 
     assert(CopyCommandParser.parse(command).map(_.copyFormat) == Some(CopyFormat.Json(None)))
@@ -52,14 +52,14 @@ class CopyCommandParserTest extends FlatSpec {
   it should "parse date format" in {
     val auto =
       s"""
-         |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |DATEFORMAT 'auto';
          |""".stripMargin
 
     val custom =
       s"""
-         |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |DATEFORMAT 'YYYY/MM/DD';
          |""".stripMargin
@@ -71,28 +71,28 @@ class CopyCommandParserTest extends FlatSpec {
   it should "parse time format" in {
     val auto =
       s"""
-         |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |TIMEFORMAT 'auto';
          |""".stripMargin
 
     val epochsecs =
       s"""
-         |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |TIMEFORMAT 'epochsecs';
          |""".stripMargin
 
     val epochmillisecs =
       s"""
-         |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |TIMEFORMAT 'epochmillisecs';
          |""".stripMargin
 
     val custom =
       s"""
-         |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/data/foo-bar.csv'
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |TIMEFORMAT 'YYYY/MM/DD HH:MI:SS.SSS';
          |""".stripMargin
@@ -106,7 +106,7 @@ class CopyCommandParserTest extends FlatSpec {
   it should "parse manifest" in {
     val command =
       s"""
-         |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/unloaded_manifest'
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/unloaded_manifest'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |MANIFEST;
          |""".stripMargin
@@ -117,7 +117,7 @@ class CopyCommandParserTest extends FlatSpec {
   it should "parse emptyAsNull" in {
     val command =
       s"""
-         |COPY public._foo_42 FROM '${Global.s3Endpoint}some-bucket/path/to/unloaded_manifest'
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/unloaded_manifest'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |EMPTYASNULL;
          |""".stripMargin

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParserTest.scala
@@ -8,7 +8,7 @@ class UnloadCommandParserTest extends FlatSpec {
   it should "parse minimal UNLOAD command" in {
     val command =
       s"""
-         |UNLOAD ('${"""SELECT * FROM foo_bar WHERE baz = \'2016-01-01\'"""}') TO '${Global.s3Endpoint}some-bucket/path/to/data'
+         |UNLOAD ('${"""SELECT * FROM foo_bar WHERE baz = \'2016-01-01\'"""}') TO '${Global.s3Scheme}some-bucket/path/to/data'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY';
          |""".stripMargin
 
@@ -30,7 +30,7 @@ class UnloadCommandParserTest extends FlatSpec {
   it should "parse Manifest" in {
     val command =
       s"""
-         |UNLOAD ('select * from foo_bar where baz = \'2016-01-01\'') TO '${Global.s3Endpoint}some-bucket/path/to/data'
+         |UNLOAD ('select * from foo_bar where baz = \'2016-01-01\'') TO '${Global.s3Scheme}some-bucket/path/to/data'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |MANIFEST;
          |""".stripMargin
@@ -41,7 +41,7 @@ class UnloadCommandParserTest extends FlatSpec {
   it should "parse delimiter" in {
     val command =
       s"""
-         |UNLOAD ('select * from foo_bar where baz = \'2016-01-01\'') TO '${Global.s3Endpoint}some-bucket/path/to/data'
+         |UNLOAD ('select * from foo_bar where baz = \'2016-01-01\'') TO '${Global.s3Scheme}some-bucket/path/to/data'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |DELIMITER ',';
          |""".stripMargin
@@ -52,7 +52,7 @@ class UnloadCommandParserTest extends FlatSpec {
   it should "parse addQuotes" in {
     val command =
       s"""
-         |UNLOAD ('select * from foo_bar where baz = \'2016-01-01\'') TO '${Global.s3Endpoint}some-bucket/path/to/data'
+         |UNLOAD ('select * from foo_bar where baz = \'2016-01-01\'') TO '${Global.s3Scheme}some-bucket/path/to/data'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |ADDQUOTES;
          |""".stripMargin
@@ -63,7 +63,7 @@ class UnloadCommandParserTest extends FlatSpec {
   it should "parse multiple options" in {
     val command =
       s"""
-         |UNLOAD ('select * from foo_bar where baz = \'2016-01-01\'') TO '${Global.s3Endpoint}some-bucket/path/to/data'
+         |UNLOAD ('select * from foo_bar where baz = \'2016-01-01\'') TO '${Global.s3Scheme}some-bucket/path/to/data'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
          |MANIFEST
          |ADDQUOTES


### PR DESCRIPTION
Thanks for writing this library. It is very helpful!
I've found it to be a bit painful to work with the custom scheme that's being used when enabling fake S3. Other libraries are not always prepared to handle that. That's why I've added the ability to customize the scheme that is being used. It shouldn't break any existing usage, as the defaults are still the same.
Let me know what you think and if you'd be interested in merging this.