### PR TITLE
copy command support for delimiter, null as and quoted table names

### DIFF
--- a/src/main/scala/jp/ne/opt/redshiftfake/CopyCommand.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/CopyCommand.scala
@@ -14,7 +14,9 @@ case class CopyCommand(
   copyFormat: CopyFormat,
   dateFormatType: DateFormatType,
   timeFormatType: TimeFormatType,
-  emptyAsNull: Boolean
+  emptyAsNull: Boolean,
+  delimiter: Char,
+  nullAs: String
 ) {
   val qualifiedTableName = schemaName match {
     case Some(schema) => s"$schema.$tableName"

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
@@ -7,6 +7,9 @@ import scala.util.parsing.combinator.RegexParsers
 
 trait BaseParser extends RegexParsers {
   val identifier = """[_a-zA-Z]\w*"""
+  val quotedIdentifier = """\"?[_a-zA-Z]\w*\"?""".r ^^ {
+    _.replaceAll("\"", "")
+  }
 
   val space = """\s*"""
 

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
@@ -7,7 +7,7 @@ import scala.util.parsing.combinator.RegexParsers
 
 trait BaseParser extends RegexParsers {
   val identifier = """[_a-zA-Z]\w*"""
-  val quotedIdentifier = """\"?[_a-zA-Z]\w*\"?""".r ^^ {
+  val quotedIdentifier = "\"".? ~> identifier.r <~ "\"".? ^^ {
     _.replaceAll("\"", "")
   }
 

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
@@ -27,6 +27,8 @@ trait BaseParser extends RegexParsers {
 
     "'" ~> parserWithKey <~ "'"
   }
+
+  val delimiterParser = s"$any*(?i)DELIMITER".r ~> "(?i)AS".r.? ~> "'" ~> """[|,]""".r <~ "'" <~ s"$any*".r ^^ { s => s.head }
 }
 
 object BaseParser extends BaseParser

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParser.scala
@@ -24,8 +24,6 @@ object CopyCommandParser extends BaseParser {
     "(?i)FORMAT".r.? ~> "(?i)AS".r.? ~> json.? ^^ (_.getOrElse(CopyFormat.Default))
   }
 
-  val delimiterParser = s"$any*(?i)DELIMITER".r ~> "(?i)AS".r.? ~> "'" ~> """[|,]""".r <~ "'" <~ s"$any*".r ^^ { s => s.head }
-
   val nullAsParser = s"$any*(?i)NULL$space+AS".r ~> "'" ~> """[^']*""".r <~ "'" <~ s"$any*".r
 
   val timeFormatParser: Parser[TimeFormatType] = {

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParser.scala
@@ -5,11 +5,11 @@ import jp.ne.opt.redshiftfake._
 object CopyCommandParser extends BaseParser {
   case class TableAndSchemaName(schemaName: Option[String], tableName: String)
 
-  val tableNameParser = ((identifier.r <~ ".").? ~ identifier.r) ^^ {
+  val tableNameParser = ((quotedIdentifier <~ ".").? ~ quotedIdentifier) ^^ {
     case ~(schemaName, tableName) => TableAndSchemaName(schemaName, tableName)
   }
 
-  val columnListParser = "(" ~> ((identifier.r <~ s",$space".r).* ~ identifier.r) <~ ")" ^^ {
+  val columnListParser = "(" ~> ((quotedIdentifier <~ s",$space".r).* ~ quotedIdentifier) <~ ")" ^^ {
     case ~(init, last) => init :+ last
   }
 
@@ -23,6 +23,10 @@ object CopyCommandParser extends BaseParser {
 
     "(?i)FORMAT".r.? ~> "(?i)AS".r.? ~> json.? ^^ (_.getOrElse(CopyFormat.Default))
   }
+
+  val delimiterParser = s"$any*(?i)DELIMITER".r ~> "(?i)AS".r.? ~> "'" ~> """[|,]""".r <~ "'" <~ s"$any*".r ^^ { s => s.head }
+
+  val nullAsParser = s"$any*(?i)NULL$space+AS".r ~> "'" ~> """[^']*""".r <~ "'" <~ s"$any*".r
 
   val timeFormatParser: Parser[TimeFormatType] = {
     s"$any*(?i)TIMEFORMAT".r ~> "(?i)AS".r.? ~>
@@ -67,7 +71,9 @@ object CopyCommandParser extends BaseParser {
           format,
           parse(dateFormatParser, dataConversionParameters).getOrElse(DateFormatType.Default),
           parse(timeFormatParser, dataConversionParameters).getOrElse(TimeFormatType.Default),
-          parse(emptyAsNullParser, dataConversionParameters).successful
+          parse(emptyAsNullParser, dataConversionParameters).successful,
+          parse(delimiterParser, dataConversionParameters).getOrElse(','),
+          parse(nullAsParser, dataConversionParameters).getOrElse("\u000e")
         )
 
         // handle manifest

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParser.scala
@@ -72,7 +72,7 @@ object CopyCommandParser extends BaseParser {
           parse(dateFormatParser, dataConversionParameters).getOrElse(DateFormatType.Default),
           parse(timeFormatParser, dataConversionParameters).getOrElse(TimeFormatType.Default),
           parse(emptyAsNullParser, dataConversionParameters).successful,
-          parse(delimiterParser, dataConversionParameters).getOrElse(','),
+          parse(delimiterParser, dataConversionParameters).getOrElse('|'),
           parse(nullAsParser, dataConversionParameters).getOrElse("\u000e")
         )
 

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParser.scala
@@ -38,8 +38,6 @@ object UnloadCommandParser extends BaseParser with QueryCompatibility {
 
   val addQuotesParser = s"$any*(?i)ADDQUOTES$any*".r
 
-  val delimiterParser = s"$any*(?i)DELIMITER".r ~> "(?i)AS".r.? ~> "'" ~> """[|,]""".r <~ "'" <~ s"$any*".r ^^ { s => s.head }
-
   val manifestParser = s"$any*(?i)MANIFEST$any*".r
 
   val statementParser = "(?i)UNLOAD".r ~> selectStatementParser ^^ { s =>

--- a/src/main/scala/jp/ne/opt/redshiftfake/read/CsvReader.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/read/CsvReader.scala
@@ -5,10 +5,10 @@ import jp.ne.opt.redshiftfake.{Column, Row}
 
 case class InvalidCsvException(message: String) extends RuntimeException
 
-class CsvReader(csvRow: String) {
+class CsvReader(csvRow: String, delimiterChar: Char, nullAs: String) {
 
   private[this] object csvFormat extends CSVFormat {
-    val delimiter: Char = '|'
+    val delimiter: Char = delimiterChar
     val quoteChar: Char = '"'
     val treatEmptyLineAsNil: Boolean = false
     val escapeChar: Char = '\\'
@@ -22,7 +22,7 @@ class CsvReader(csvRow: String) {
     // to recognize last field when the field is empty.
     val parsed = parser.parseLine(csvRow + csvFormat.delimiter + emptyField)
     parsed.map { xs => Row(xs.map {
-      column => Column(if (column.nonEmpty) Some(column) else None)
+      column => Column(if (column.nonEmpty && column != nullAs) Some(column) else None)
     })}.getOrElse(throw InvalidCsvException(s"invalid csv row : $csvRow"))
   }
 }

--- a/src/main/scala/jp/ne/opt/redshiftfake/read/Reader.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/read/Reader.scala
@@ -40,7 +40,7 @@ class Reader(copyCommand: CopyCommand, columnDefinitions: Seq[ColumnDefinition],
           content <- contents
           line <- content.trim.lines
         } yield {
-          val csvReader = new CsvReader(line)
+          val csvReader = new CsvReader(line, copyCommand.delimiter, copyCommand.nullAs)
           csvReader.toRow
         })(collection.breakOut)
       case _ => Nil

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
@@ -25,7 +25,7 @@ class CopyCommandParserTest extends FlatSpec {
       dateFormatType = DateFormatType.Default,
       timeFormatType = TimeFormatType.Default,
       emptyAsNull = false,
-      delimiter = ',',
+      delimiter = '|',
       nullAs = "\u000e"
     )
 
@@ -146,11 +146,11 @@ class CopyCommandParserTest extends FlatSpec {
          |COPY "public"."mytable"
          |FROM '${Global.s3Scheme}some-bucket/path/to/unloaded_manifest.json'
          |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
-         |DELIMITER AS '|'
+         |DELIMITER AS ','
          |manifest
          |""".stripMargin
 
-    assert(CopyCommandParser.parse(command).map(_.delimiter) == Some('|'))
+    assert(CopyCommandParser.parse(command).map(_.delimiter) == Some(','))
   }
 
   it should "set default delimiter correctly" in {
@@ -163,7 +163,7 @@ class CopyCommandParserTest extends FlatSpec {
          |manifest
          |""".stripMargin
 
-    assert(CopyCommandParser.parse(command).map(_.delimiter) == Some(','))
+    assert(CopyCommandParser.parse(command).map(_.delimiter) == Some('|'))
   }
 
   it should "parse 'null as' from copy command" in {


### PR DESCRIPTION
I ran into some generated COPY queries that were making use of
- Quoted schema and tables names
- NULL AS
- DELIMITER AS

This pull request adds support for these to the CopyCommandParser. Let me know what you think.