### PR TITLE
feat: Filter out Alter Table Append statements

### DIFF
--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/DDLParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/DDLParser.scala
@@ -13,8 +13,15 @@ object DDLParser extends BaseParser {
   }
   val encodeRegex = s"(?i)${space}ENCODE$space$identifier$space".r
 
+  //https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE_APPEND.html
+  //ALTER TABLE target_table_name APPEND FROM source_table_name[ IGNOREEXTRA | FILLTARGET ]
+  //It is just for moving data, so we can ignore it and the schema will not be affected
+  //The closest postgres equivalent is WITH https://stackoverflow.com/questions/2974057/move-data-from-one-table-to-another-postgresql-edition
+  //However, that requires the columns to match, whereas this allows one or other of the tables to have extra or ignored columns
+  val alterTableAppendRegex = s"(?i)ALTER${space}TABLE${space}${identifier}${space}APPEND${space}FROM${space}${identifier}(${space}(IGNOREEXTRA|FILLTARGET))?".r ///
+
   def sanitize(ddl: String): String = {
-    Seq(distStyleRegex, distKeyRegex, sortKeyRegex, encodeRegex).foldLeft(ddl) { (current, regex) =>
+    Seq(distStyleRegex, distKeyRegex, sortKeyRegex, encodeRegex, alterTableAppendRegex).foldLeft(ddl) { (current, regex) =>
       regex.replaceAllIn(current, "")
     }
   }

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/DDLParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/DDLParserTest.scala
@@ -22,4 +22,10 @@ class DDLParserTest extends FlatSpec {
 
     assert(DDLParser.sanitize(ddl) == expected)
   }
+
+  it should "drop alter table append statements" in {
+    assert(DDLParser.sanitize("ALTER TABLE sales APPEND FROM sales_monthly") == "")
+    assert(DDLParser.sanitize("ALTER TABLE sales APPEND FROM sales_monthly ignoreextra") == "")
+    assert(DDLParser.sanitize("ALTER TABLE sales APPEND FROM sales_monthly FILLTARGET") == "")
+  }
 }


### PR DESCRIPTION
Postgres doesn't support this https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE_APPEND.html

It would be possible to write some crazy code to convert it to a WITH ... INSERT INTO statement, but since it does not change the schema and only moves data from one table to another I think it would be ok to drop it. What do you think?