### PR TITLE
Replace indentity in DDL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ licenses += "Apache 2" -> url("https://raw.githubusercontent.com/opt-tech/redshi
 
 organization := "jp.ne.opt"
 
-version := "1.0.7-SNAPSHOT"
+version := "1.0.8-SNAPSHOT"
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import Deps._
 import Helpers._
-import sbtassembly.AssemblyPlugin.autoImport._
 
 val scala210 = "2.10.7"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import Deps._
 import Helpers._
+import sbtassembly.AssemblyPlugin.autoImport._
 
 val scala210 = "2.10.7"
 
@@ -13,7 +14,7 @@ licenses += "Apache 2" -> url("https://raw.githubusercontent.com/opt-tech/redshi
 
 organization := "jp.ne.opt"
 
-version := "1.0.8-SNAPSHOT"
+version := "1.0.7-SNAPSHOT"
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
@@ -16,6 +16,8 @@ trait BaseParser extends RegexParsers {
 
   val any = """(.|\s)"""
 
+  val number = """(0|[1-9]\d*)"""
+
   val s3LocationParser = Global.s3Scheme ~> """[\w-]+""".r ~ ("/" ~> """[\w/:%#$&?()~.=+-]+""".r).? ^^ {
     case ~(bucket, prefix) => S3Location(bucket, prefix.getOrElse(""))
   }

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/DDLParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/DDLParser.scala
@@ -13,9 +13,15 @@ object DDLParser extends BaseParser {
   }
   val encodeRegex = s"(?i)${space}ENCODE$space$identifier$space".r
 
+  val identityBigintRegexp = s"(?i)(BIGINT)${space}IDENTITY$space\\($space$number\\,$space$number\\)".r
+
   def sanitize(ddl: String): String = {
-    Seq(distStyleRegex, distKeyRegex, sortKeyRegex, encodeRegex).foldLeft(ddl) { (current, regex) =>
+    val cleanedDdl = Seq(distStyleRegex, distKeyRegex, sortKeyRegex, encodeRegex).foldLeft(ddl) { (current, regex) =>
       regex.replaceAllIn(current, "")
+    }
+
+    Seq(identityBigintRegexp).foldLeft(cleanedDdl) { (current, regex) =>
+      regex.replaceAllIn(current, "bigserial")
     }
   }
 }

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/DDLParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/DDLParserTest.scala
@@ -6,7 +6,7 @@ class DDLParserTest extends FlatSpec {
   it should "sanitize Redshift specific DDL" in {
     val ddl =
       """
-        |CREATE TABLE foo_bar(a int ENCODE ZSTD, b boolean)
+        |CREATE TABLE foo_bar(a int ENCODE ZSTD, b boolean, c bigint IDENTITY(1,1), d bigint IDENTITY(10,5))
         |DISTSTYLE ALL
         |DISTKEY(a)
         |INTERLEAVED SORTKEY(a, b);
@@ -14,7 +14,7 @@ class DDLParserTest extends FlatSpec {
 
     val expected =
       """
-        |CREATE TABLE foo_bar(a int, b boolean)
+        |CREATE TABLE foo_bar(a int, b boolean, c bigserial, d bigserial)
         |
         |
         |;


### PR DESCRIPTION
This replacement help to workaround using IDENTITY in redshift DDL: replaced with BIGSERIAL type of Postgres.
Sorry, this my very first time with Scala.