### PR TITLE
Add S3Sandbox for IntegrationTest, add ability to set s3Client for db driver manually, add ability to copy from gzipped files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,4 @@ matrix:
     jdk: openjdk8
 
 script:
-  - gem install fakes3
-  - fakes3 -r ./fakes3_root -p 9444 &
-  - sbt -Dfake.awsS3Endpoint="http://localhost:9444/" ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,9 @@ scalacOptions ++= Seq(
   "-feature"
 )
 
-libraryDependencies ++= (compileScope(jawn, jsqlparser, scalaCsv) ++
+libraryDependencies ++= (compileScope(jawn, jsqlparser, scalaCsv, commonsCompress) ++
   (if (scalaVersion.value.startsWith("2.10")) Nil else compileScope(parser)) ++
-  testScope(postgres, h2, s3, sts, scalatest) ++
+  testScope(postgres, h2, s3, sts, scalatest, s3Proxy) ++
   providedScope(postgres, h2, s3, sts))
 
 publishMavenStyle := true

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -10,4 +10,6 @@ object Deps {
   val sts = "com.amazonaws" % "aws-java-sdk-sts" % "1.11.43"
   val jawn = "org.spire-math" %% "jawn-ast" % "0.10.4"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.0"
+  val s3Proxy = "org.gaul" % "s3proxy" % "1.6.0"
+  val commonsCompress = "org.apache.commons" % "commons-compress" % "1.17"
 }

--- a/src/main/java/jp/ne/opt/redshiftfake/postgres/FakePostgresqlDriver.java
+++ b/src/main/java/jp/ne/opt/redshiftfake/postgres/FakePostgresqlDriver.java
@@ -2,6 +2,7 @@ package jp.ne.opt.redshiftfake.postgres;
 
 import jp.ne.opt.redshiftfake.FakeConnection;
 import jp.ne.opt.redshiftfake.Global;
+import jp.ne.opt.redshiftfake.s3.S3Service;
 import jp.ne.opt.redshiftfake.s3.S3ServiceImpl;
 import jp.ne.opt.redshiftfake.views.SystemViews;
 import org.postgresql.Driver;
@@ -13,6 +14,7 @@ import java.util.Properties;
 
 public class FakePostgresqlDriver extends Driver {
     private static final String urlPrefix = "jdbc:postgresqlredshift";
+    private static S3Service s3Service;
 
     static {
         try {
@@ -20,6 +22,10 @@ public class FakePostgresqlDriver extends Driver {
         } catch (SQLException e) {
             e.printStackTrace();
         }
+    }
+
+    public static void setS3Service(S3Service service) {
+        s3Service = service;
     }
 
     @Override
@@ -30,10 +36,8 @@ public class FakePostgresqlDriver extends Driver {
             final Connection connection = DriverManager.getConnection(postgresUrl, info);
             SystemViews.create(connection);
 
-            return new FakeConnection(
-                    connection,
-                    new S3ServiceImpl(Global.s3Endpoint())
-            );
+            return new FakeConnection(connection,
+                    s3Service == null ? new S3ServiceImpl(Global.s3Endpoint()) : s3Service);
         } else {
             return null;
         }

--- a/src/main/java/org/h2/jdbc/FakeH2Driver.java
+++ b/src/main/java/org/h2/jdbc/FakeH2Driver.java
@@ -2,6 +2,7 @@ package org.h2.jdbc;
 
 import jp.ne.opt.redshiftfake.FakeConnection;
 import jp.ne.opt.redshiftfake.Global;
+import jp.ne.opt.redshiftfake.s3.S3Service;
 import jp.ne.opt.redshiftfake.s3.S3ServiceImpl;
 import org.h2.Driver;
 
@@ -12,6 +13,7 @@ import java.util.Properties;
 
 public class FakeH2Driver extends Driver {
     private static final String urlPrefix = "jdbc:h2redshift";
+    private static S3Service s3Service;
 
     static {
         try {
@@ -21,14 +23,16 @@ public class FakeH2Driver extends Driver {
         }
     }
 
+    public static void setS3Service(S3Service service) {
+        s3Service = service;
+    }
+
     @Override
     public Connection connect(String url, Properties info) throws SQLException {
         if (url.startsWith(urlPrefix)) {
             String h2Url = url.replaceFirst(urlPrefix, "jdbc:h2");
-            return new FakeConnection(
-                    DriverManager.getConnection(h2Url, info),
-                    new S3ServiceImpl(Global.s3Endpoint())
-            );
+            return new FakeConnection(DriverManager.getConnection(h2Url, info),
+                    s3Service == null ? new S3ServiceImpl(Global.s3Endpoint()) : s3Service);
         } else {
             return null;
         }

--- a/src/main/scala/jp/ne/opt/redshiftfake/CopyCommand.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/CopyCommand.scala
@@ -16,7 +16,8 @@ case class CopyCommand(
   timeFormatType: TimeFormatType,
   emptyAsNull: Boolean,
   delimiter: Char,
-  nullAs: String
+  nullAs: String,
+  compression: FileCompressionParameter
 ) {
   val qualifiedTableName = schemaName match {
     case Some(schema) => s"$schema.$tableName"
@@ -50,4 +51,11 @@ object TimeFormatType {
   case object Epochsecs extends TimeFormatType
   case object EpochMillisecs extends TimeFormatType
   case class Custom(pattern: String) extends TimeFormatType
+}
+
+sealed abstract class FileCompressionParameter
+object FileCompressionParameter {
+  case object None extends FileCompressionParameter
+  case object Gzip extends FileCompressionParameter
+  case object Bzip2 extends FileCompressionParameter
 }

--- a/src/main/scala/jp/ne/opt/redshiftfake/read/Reader.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/read/Reader.scala
@@ -15,14 +15,14 @@ class Reader(copyCommand: CopyCommand, columnDefinitions: Seq[ColumnDefinition],
       case (CopyFormat.Manifest(location), _) =>
         val rawManifest = s3Service.downloadAsString(location)(copyCommand.credentials)
         val manifest = new Manifest(rawManifest)
-        manifest.files.map(s3Service.downloadAsString(_)(copyCommand.credentials))
+        manifest.files.map(s3Service.downloadAsString(_, copyCommand.compression)(copyCommand.credentials))
       case (_, CopyDataSource.S3(location)) =>
-        downloadAllAsStringFromS3(location)
+        downloadAllAsStringFromS3(location, copyCommand.compression)
     }
 
     copyCommand.copyFormat match {
       case CopyFormat.Json(Some(jsonpathsLocation)) =>
-        val rawJsonpaths = s3Service.downloadAsString(S3Location(jsonpathsLocation.bucket, jsonpathsLocation.prefix))(copyCommand.credentials)
+        val rawJsonpaths = s3Service.downloadAsString(S3Location(jsonpathsLocation.bucket, jsonpathsLocation.prefix), copyCommand.compression)(copyCommand.credentials)
         val jsonpaths = new Jsonpaths(rawJsonpaths)
 
         (for {
@@ -47,10 +47,10 @@ class Reader(copyCommand: CopyCommand, columnDefinitions: Seq[ColumnDefinition],
     }
   }
 
-  private[this] def downloadAllAsStringFromS3(location: S3Location): Seq[String] = {
+  private[this] def downloadAllAsStringFromS3(location: S3Location, compression: FileCompressionParameter): Seq[String] = {
     val summaries = s3Service.lsRecurse(location)(copyCommand.credentials)
     summaries.map { summary =>
-      s3Service.downloadAsString(S3Location(location.bucket, summary.getKey))(copyCommand.credentials)
+      s3Service.downloadAsString(S3Location(location.bucket, summary.getKey), compression)(copyCommand.credentials)
     }
   }
 }

--- a/src/test/scala/jp/ne/opt/redshiftfake/IntegrationTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/IntegrationTest.scala
@@ -1,19 +1,32 @@
 package jp.ne.opt.redshiftfake
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
+import java.util.zip.GZIPOutputStream
 
-import jp.ne.opt.redshiftfake.s3.S3ServiceImpl
+import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
+import jp.ne.opt.redshiftfake.s3.S3ServiceImplWithCustomClient
+import org.h2.jdbc.FakeH2Driver
 import org.scalatest.fixture
+import jp.ne.opt.redshiftfake.util.Loan.using
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
 
-class IntegrationTest extends fixture.FlatSpec with H2Sandbox with CIOnly {
+class IntegrationTest extends fixture.FlatSpec
+  with H2Sandbox
+  with S3Sandbox {
+
+  val s3Endpoint = "http://127.0.0.1:7887"
+  val s3Region = "ap-northeast-1"
+  val dummyCredentials = Credentials.WithKey("AKIAXXXXXXXXXXXXXXX", "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY")
+  val s3Client = createS3Client(s3Region)
+  val s3Service = new S3ServiceImplWithCustomClient(s3Client)
+
+  FakeH2Driver.setS3Service(s3Service)
 
   it should "unload / copy via manifest" in { conn =>
-    skiplIfLocalEnvironment()
-
     // create bucket
-    val dummyCredentials = Credentials.WithKey("AKIAXXXXXXXXXXXXXXX", "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY")
-    val s3Service = new S3ServiceImpl(Global.s3Endpoint)
-    s3Service.mkClient(dummyCredentials).createBucket("foo")
+    s3Client.createBucket("foo")
 
     // create source table
     conn.createStatement().execute("create table foo(a int, b boolean, c date)")
@@ -52,5 +65,95 @@ class IntegrationTest extends fixture.FlatSpec with H2Sandbox with CIOnly {
       ("2016-11-20", 1, 1),
       ("2016-11-21", 2, 8)
     ))
+  }
+
+  it should "success copy from gzipped files with GZIP option" in { conn =>
+    val bucket = "gzipped"
+    val gzipped =
+      """1,true,2016-11-20
+        |4,false,2016-11-21
+      """.stripMargin
+    val fileKey = "gzipped.txt.gz"
+
+    s3Client.createBucket("gzipped")
+    loadGzippedDataToS3(gzipped, bucket, fileKey)
+    conn.createStatement().execute("create table gzipped(a int, b boolean, c date)")
+
+    conn.createStatement().execute(
+      s"""copy gzipped from '${Global.s3Scheme}$bucket/$fileKey'
+         |credentials 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
+         |delimiter ','
+         |dateformat 'auto'
+         |gzip""".stripMargin
+    )
+
+    val resultSet = conn.createStatement().executeQuery("select * from gzipped order by c")
+    val result = Iterator.continually(resultSet).takeWhile(_.next()).map { rs =>
+      val sdf = new SimpleDateFormat("yyyy-MM-dd")
+      (sdf.format(rs.getDate("c")), rs.getInt("a"), rs.getBoolean("b"))
+    }.toList
+
+    assert(result == List(
+      ("2016-11-20", 1, true),
+      ("2016-11-21", 4, false)
+    ))
+  }
+
+  it should "success copy from bzipped2 files with GZIP option" in { conn =>
+    val bucket = "bzipped2"
+    val bzipped2 =
+      """1,true,2016-11-20
+        |4,false,2016-11-21
+      """.stripMargin
+    val fileKey = "bzipped2.txt.gz"
+
+    s3Client.createBucket("bzipped2")
+    loadBzipped2DataToS3(bzipped2, bucket, fileKey)
+    conn.createStatement().execute("create table bzipped2(a int, b boolean, c date)")
+
+    conn.createStatement().execute(
+      s"""copy bzipped2 from '${Global.s3Scheme}$bucket/$fileKey'
+         |credentials 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
+         |delimiter ','
+         |dateformat 'auto'
+         |bzip2""".stripMargin
+    )
+
+    val resultSet = conn.createStatement().executeQuery("select * from bzipped2 order by c")
+    val result = Iterator.continually(resultSet).takeWhile(_.next()).map { rs =>
+      val sdf = new SimpleDateFormat("yyyy-MM-dd")
+      (sdf.format(rs.getDate("c")), rs.getInt("a"), rs.getBoolean("b"))
+    }.toList
+
+    assert(result == List(
+      ("2016-11-20", 1, true),
+      ("2016-11-21", 4, false)
+    ))
+  }
+
+  private def loadGzippedDataToS3(data: String, bucket: String, key: String): Unit = {
+    val arrayOutputStream = new ByteArrayOutputStream()
+    using(new GZIPOutputStream(arrayOutputStream)) (gzipOutStream => {
+      gzipOutStream.write(data.getBytes(StandardCharsets.UTF_8))
+    })
+    val buf = arrayOutputStream.toByteArray
+    val metadata = new ObjectMetadata
+    metadata.setContentLength(buf.length)
+    val request = new PutObjectRequest(bucket, key, new ByteArrayInputStream(buf), metadata)
+
+    s3Client.putObject(request)
+  }
+
+  private def loadBzipped2DataToS3(data: String, bucket: String, key: String): Unit = {
+    val arrayOutputStream = new ByteArrayOutputStream()
+    using(new BZip2CompressorOutputStream(arrayOutputStream)) (bzip2OutStream => {
+      bzip2OutStream.write(data.getBytes(StandardCharsets.UTF_8))
+    })
+    val buf = arrayOutputStream.toByteArray
+    val metadata = new ObjectMetadata
+    metadata.setContentLength(buf.length)
+    val request = new PutObjectRequest(bucket, key, new ByteArrayInputStream(buf), metadata)
+
+    s3Client.putObject(request)
   }
 }

--- a/src/test/scala/jp/ne/opt/redshiftfake/S3Sandbox.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/S3Sandbox.scala
@@ -1,0 +1,45 @@
+package jp.ne.opt.redshiftfake
+
+import java.net.URI
+
+import com.amazonaws.auth.{AWSCredentials, BasicAWSCredentials}
+import com.amazonaws.regions.RegionUtils
+import com.amazonaws.services.s3.AmazonS3Client
+import org.gaul.s3proxy.{AuthenticationType, S3Proxy}
+import org.jclouds.ContextBuilder
+import org.jclouds.blobstore.BlobStoreContext
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait S3Sandbox extends BeforeAndAfterAll {this: Suite =>
+
+  val dummyCredentials:  Credentials.WithKey
+  val s3Endpoint: String
+
+  var s3Proxy: S3Proxy = _
+
+  override def beforeAll(): Unit = {
+    val blobContext: BlobStoreContext = ContextBuilder
+      .newBuilder("transient")
+      .build(classOf[BlobStoreContext])
+
+    s3Proxy = S3Proxy.builder
+      .blobStore(blobContext.getBlobStore)
+      .awsAuthentication(AuthenticationType.AWS_V4, dummyCredentials.accessKeyId, dummyCredentials.secretAccessKey)
+      .endpoint(URI.create(s3Endpoint))
+      .build
+    s3Proxy.start()
+  }
+
+  override def afterAll(): Unit = {
+    s3Proxy.stop()
+  }
+
+  def createS3Client(s3Region: String): AmazonS3Client = {
+    val credentials: AWSCredentials = new BasicAWSCredentials(dummyCredentials.accessKeyId, dummyCredentials.secretAccessKey)
+    val client = new AmazonS3Client(credentials)
+    client.setRegion(RegionUtils.getRegion(s3Region))
+    client.setEndpoint(s3Endpoint)
+
+    client
+  }
+}

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
@@ -26,7 +26,8 @@ class CopyCommandParserTest extends FlatSpec {
       timeFormatType = TimeFormatType.Default,
       emptyAsNull = false,
       delimiter = '|',
-      nullAs = "\u000e"
+      nullAs = "\u000e",
+      compression = FileCompressionParameter.None
     )
 
     assert(new CopyCommandParser().parse(command) == Some(expected))
@@ -210,10 +211,42 @@ class CopyCommandParserTest extends FlatSpec {
       timeFormatType = TimeFormatType.Default,
       emptyAsNull = false,
       delimiter = '|',
-      nullAs = "\u000e"
+      nullAs = "\u000e",
+      compression = FileCompressionParameter.None
     )
 
     assert(new CopyCommandParser().parse(command) == Some(expected))
   }
 
+  it should "parse GZIP from copy command" in {
+    val command =
+      s"""
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv.gz'
+         |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
+         |GZIP
+         |""".stripMargin
+
+    assert(new CopyCommandParser().parse(command).map(_.compression) == Some(FileCompressionParameter.Gzip))
+  }
+
+  it should "parse BZIP2 from copy command" in {
+    val command =
+      s"""
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv.gz'
+         |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
+         |BZIP2
+         |""".stripMargin
+
+    assert(new CopyCommandParser().parse(command).map(_.compression) == Some(FileCompressionParameter.Bzip2))
+  }
+
+  it should "set default file compression correctly" in {
+    val command =
+      s"""
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv.gz'
+         |CREDENTIALS 'aws_access_key_id=AKIAXXXXXXXXXXXXXXX;aws_secret_access_key=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY';
+         |""".stripMargin
+
+    assert(new CopyCommandParser().parse(command).map(_.compression) == Some(FileCompressionParameter.None))
+  }
 }


### PR DESCRIPTION
Hello!
I use your library in my work project for testing purposes.
I need some changes will be done. And then I can use library without patches that created by me and my colleagues.
1. I change your integration test (create S3Sandbox class) and now it uses fake s3, so you can run this test not only on CI-server, but on the developer machine.
2. Also I add an ability to make copy command with gzip/bzip2 files
3. I add an ability to set s3Client (s3Service) manually to fake-driver. In our project we don-t use environment variables, only config files. And thats why we need this ability.

(We also need some other changes in future)

Please, review my pr and write your notes.
Thank you.