### PR TITLE
Add check for columnList in copy command and for inserted values count

### DIFF
--- a/src/main/scala/jp/ne/opt/redshiftfake/FakeAmazonSQLException.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/FakeAmazonSQLException.scala
@@ -1,0 +1,3 @@
+package jp.ne.opt.redshiftfake
+
+case class FakeAmazonSQLException(msg: String) extends RuntimeException(msg)

--- a/src/test/scala/jp/ne/opt/redshiftfake/S3Util.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/S3Util.scala
@@ -1,0 +1,48 @@
+package jp.ne.opt.redshiftfake
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.charset.StandardCharsets
+import java.util.zip.GZIPOutputStream
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
+import jp.ne.opt.redshiftfake.util.Loan.using
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
+
+object S3Util {
+
+   def loadGzippedDataToS3(s3Client: AmazonS3, data: String, bucket: String, key: String): Unit = {
+    val arrayOutputStream = new ByteArrayOutputStream()
+    using(new GZIPOutputStream(arrayOutputStream)) (gzipOutStream => {
+      gzipOutStream.write(data.getBytes(StandardCharsets.UTF_8))
+    })
+    val buf = arrayOutputStream.toByteArray
+    val metadata = new ObjectMetadata
+    metadata.setContentLength(buf.length)
+    val request = new PutObjectRequest(bucket, key, new ByteArrayInputStream(buf), metadata)
+
+    s3Client.putObject(request)
+  }
+
+   def loadBzipped2DataToS3(s3Client: AmazonS3, data: String, bucket: String, key: String): Unit = {
+    val arrayOutputStream = new ByteArrayOutputStream()
+    using(new BZip2CompressorOutputStream(arrayOutputStream)) (bzip2OutStream => {
+      bzip2OutStream.write(data.getBytes(StandardCharsets.UTF_8))
+    })
+    val buf = arrayOutputStream.toByteArray
+    val metadata = new ObjectMetadata
+    metadata.setContentLength(buf.length)
+    val request = new PutObjectRequest(bucket, key, new ByteArrayInputStream(buf), metadata)
+
+    s3Client.putObject(request)
+  }
+
+   def loadDataToS3(s3Client: AmazonS3, data: String, bucket: String, key: String): Unit = {
+    val buf = data.getBytes
+    val metadata = new ObjectMetadata
+    metadata.setContentLength(buf.length)
+    val request = new PutObjectRequest(bucket, key, new ByteArrayInputStream(buf), metadata)
+
+    s3Client.putObject(request)
+  }
+}


### PR DESCRIPTION
Hello!
As I said previously, my team uses this library for testing purposes.
Our copy command is 
`copy <table_name>(<column_list>) from 's3://<bucket>' credentials 'aws_access_key_id=<access>;aws_secret_access_key=<secret>' csv timeformat 'auto' delimiter ',' gzip;` 
(<..> is a placeholder).
There were 2 bugs in our app:
- sometimes we passed wrong column list to copy command
- sometimes we passed more values for insertion in our csv file.

And we have known about it only on prod environment.
Thats why, I suggest to add 2 checks:
- check that all columns from <column_list> exist in database
- check that it is passed enough value for insertion.

Please, do review and make you notes.
Thank you. 