### PR TITLE
WithTemporaryToken authorizaton can handle token which has slash or plus sign in it

### DIFF
--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
@@ -32,7 +32,7 @@ trait BaseParser extends RegexParsers {
   }
 
   val awsAuthTemporaryParser = {
-    "(?i)ACCESS_KEY_ID".r ~ "'" ~ """[\w]+""".r ~ "'" ~ "(?i)SECRET_ACCESS_KEY".r ~ "'" ~ """[\w]+""".r ~ "'" ~ ("(?i)SESSION_TOKEN".r | "(?i)TOKEN".r) ~ "'" ~ """[\w]+""".r ~ "'" ^^ {
+    "(?i)ACCESS_KEY_ID".r ~ "'" ~ """[\w/+=]+""".r ~ "'" ~ "(?i)SECRET_ACCESS_KEY".r ~ "'" ~ """[\w/+=]+""".r ~ "'" ~ ("(?i)SESSION_TOKEN".r | "(?i)TOKEN".r) ~ "'" ~ """[\w/+=]+""".r ~ "'" ^^ {
       case _ ~ _ ~ accessKeyId ~ _ ~ _ ~ _ ~ secretAccessKey ~ _ ~ _ ~ _ ~ sessionToken ~ _=>
         Credentials.WithTemporaryToken(
           accessKeyId,

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
@@ -219,11 +219,8 @@ class CopyCommandParserTest extends FlatSpec {
   }
 
   it should "parse ACCESS_KEY_ID and SECRET_ACCESS_KEY and SESSION_TOKEN from COPY command" in {
+    val someSessionToken = "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8/+OtkIKGO7fAE"
 
-    val someSessionToken =
-      """AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3cT6UDdyJw
-        |OOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaI
-        |v2BXIa2R4OlgkBN9bkUDNCJiBebXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE""".stripMargin
 
     val command =
       s"""

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
@@ -219,12 +219,18 @@ class CopyCommandParserTest extends FlatSpec {
   }
 
   it should "parse ACCESS_KEY_ID and SECRET_ACCESS_KEY and SESSION_TOKEN from COPY command" in {
+
+    val someSessionToken =
+      """AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3cT6UDdyJw
+        |OOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaI
+        |v2BXIa2R4OlgkBN9bkUDNCJiBebXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE""".stripMargin
+
     val command =
       s"""
          |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
          |ACCESS_KEY_ID 'some_access_key_id'
          |SECRET_ACCESS_KEY 'some_secret_access_key'
-         |SESSION_TOKEN 'some_session_token';
+         |SESSION_TOKEN '$someSessionToken';
          |""".stripMargin
 
     val expected = CopyCommand(
@@ -232,7 +238,7 @@ class CopyCommandParserTest extends FlatSpec {
       tableName = "_foo_42",
       columnList = None,
       dataSource = CopyDataSource.S3(S3Location("some-bucket", "path/to/data/foo-bar.csv")),
-      credentials = Credentials.WithTemporaryToken("some_access_key_id", "some_secret_access_key", "some_session_token"),
+      credentials = Credentials.WithTemporaryToken("some_access_key_id", "some_secret_access_key", someSessionToken),
       copyFormat = CopyFormat.Default,
       dateFormatType = DateFormatType.Default,
       timeFormatType = TimeFormatType.Default,

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParserTest.scala
@@ -116,10 +116,7 @@ class UnloadCommandParserTest extends FlatSpec {
   }
 
   it should "parse UNLOAD command with ACCESS_KEY_ID and SECRET_ACCESS_KEY and TOKEN" in {
-    val someSessionToken =
-      """AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3cT6UDdyJw
-        |OOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaI
-        |v2BXIa2R4OlgkBN9bkUDNCJiBebXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE""".stripMargin
+    val someSessionToken = "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8/+OtkIKGO7fAE"
 
     val command =
       s"""

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParserTest.scala
@@ -116,18 +116,23 @@ class UnloadCommandParserTest extends FlatSpec {
   }
 
   it should "parse UNLOAD command with ACCESS_KEY_ID and SECRET_ACCESS_KEY and TOKEN" in {
+    val someSessionToken =
+      """AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3cT6UDdyJw
+        |OOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaI
+        |v2BXIa2R4OlgkBN9bkUDNCJiBebXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE""".stripMargin
+
     val command =
       s"""
          |UNLOAD ('${"""SELECT * FROM foo_bar WHERE baz = \'2016-01-01\'"""}') TO '${Global.s3Scheme}some-bucket/path/to/data'
          |ACCESS_KEY_ID 'some_access_key_id'
          |SECRET_ACCESS_KEY 'some_secret_access_key'
-         |TOKEN 'some_session_token';
+         |TOKEN '$someSessionToken';
          |""".stripMargin
 
     val expected = UnloadCommand(
       selectStatement = "SELECT * FROM foo_bar WHERE baz = '2016-01-01'",
       destination = S3Location("some-bucket", "path/to/data"),
-      credentials = Credentials.WithTemporaryToken("some_access_key_id", "some_secret_access_key", "some_session_token"),
+      credentials = Credentials.WithTemporaryToken("some_access_key_id", "some_secret_access_key", someSessionToken),
       createManifest = false,
       delimiter = '|',
       addQuotes = false


### PR DESCRIPTION
- Updated regex for parsing access key, secret access key and token
- Updated tests which now contain slash and plus sign in the session token