### PR TITLE
Add COPY/UNLOAD creadentials format 'iam_role'

### DIFF
--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/BaseParser.scala
@@ -42,5 +42,12 @@ trait BaseParser extends RegexParsers {
     }
   }
 
+  val awsAuthAwsRoleParser = {
+    "(?i)iam_role".r ~ "'" ~ """[\w/+=:-]+""".r ~ "'" ^^ {
+      case _ ~ _ ~ iamRole~ _=>
+        Credentials.WithRole(iamRole)
+    }
+  }
+
   val delimiterParser = s"$any*(?i)DELIMITER".r ~> "(?i)AS".r.? ~> "'" ~> """[|,]""".r <~ "'" <~ s"$any*".r ^^ { s => s.head }
 }

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParser.scala
@@ -66,7 +66,7 @@ class CopyCommandParser extends BaseParser {
       ("(?i)COPY".r ~> tableNameParser) ~
         columnListParser.? ~
         ("(?i)FROM".r ~> dataSourceParser) ~
-        (("(?i)WITH".r.? ~> "(?i)CREDENTIALS".r ~> "(?i)AS".r.? ~> awsAuthArgsParser) | awsAuthTemporaryParser) ~
+        (("(?i)WITH".r.? ~> "(?i)CREDENTIALS".r ~> "(?i)AS".r.? ~> awsAuthArgsParser) | awsAuthTemporaryParser | awsAuthAwsRoleParser) ~
         copyFormatParser ~
         s"$any*".r ^^ { case ~(~(~(~(~(TableAndSchemaName(schemaName, tableName), columnList), dataSource), auth), format), dataConversionParameters) =>
         val command = CopyCommand(

--- a/src/main/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParser.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParser.scala
@@ -49,7 +49,7 @@ class UnloadCommandParser extends BaseParser with QueryCompatibility {
     val result = parse(
       statementParser ~
         ("(?i)TO".r ~> "'" ~> s3LocationParser <~ "'") ~
-        (("(?i)WITH".r.? ~> "(?i)CREDENTIALS".r ~> "(?i)AS".r.? ~> awsAuthArgsParser) | awsAuthTemporaryParser) ~
+        (("(?i)WITH".r.? ~> "(?i)CREDENTIALS".r ~> "(?i)AS".r.? ~> awsAuthArgsParser) | awsAuthTemporaryParser | awsAuthAwsRoleParser) ~
         s"$any*".r ^^ { case ~(~(~(statement, s3Location), auth), unloadOptions) =>
         UnloadCommand(
           dropIncompatibilities(statement),

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/CopyCommandParserTest.scala
@@ -275,6 +275,31 @@ class CopyCommandParserTest extends FlatSpec {
     assert(new CopyCommandParser().parse(command) == Some(expected))
   }
 
+  it should "parse iam_role credentials from COPY command" in {
+    val command =
+      s"""
+         |COPY public._foo_42 FROM '${Global.s3Scheme}some-bucket/path/to/data/foo-bar.csv'
+         |iam_role 'arn:aws:iam::12345:role/some-role';
+         |""".stripMargin
+
+    val expected = CopyCommand(
+      schemaName = Some("public"),
+      tableName = "_foo_42",
+      columnList = None,
+      dataSource = CopyDataSource.S3(S3Location("some-bucket", "path/to/data/foo-bar.csv")),
+      credentials = Credentials.WithRole("arn:aws:iam::12345:role/some-role"),
+      copyFormat = CopyFormat.Default,
+      dateFormatType = DateFormatType.Default,
+      timeFormatType = TimeFormatType.Default,
+      emptyAsNull = false,
+      delimiter = '|',
+      nullAs = "\u000e",
+      compression = FileCompressionParameter.None
+    )
+
+    assert(new CopyCommandParser().parse(command) == Some(expected))
+  }
+
   it should "parse GZIP from copy command" in {
     val command =
       s"""

--- a/src/test/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParserTest.scala
+++ b/src/test/scala/jp/ne/opt/redshiftfake/parse/UnloadCommandParserTest.scala
@@ -137,5 +137,25 @@ class UnloadCommandParserTest extends FlatSpec {
 
     assert(new UnloadCommandParser().parse(command) == Some(expected))
   }
+
+  it should "parse UNLOAD command with iam_role" in {
+
+    val command =
+      s"""
+         |UNLOAD ('${"""SELECT * FROM foo_bar WHERE baz = \'2016-01-01\'"""}') TO '${Global.s3Scheme}some-bucket/path/to/data'
+         |iam_role 'arn:aws:iam::12345:role/some-role';
+         |""".stripMargin
+
+    val expected = UnloadCommand(
+      selectStatement = "SELECT * FROM foo_bar WHERE baz = '2016-01-01'",
+      destination = S3Location("some-bucket", "path/to/data"),
+      credentials = Credentials.WithRole("arn:aws:iam::12345:role/some-role"),
+      createManifest = false,
+      delimiter = '|',
+      addQuotes = false
+    )
+
+    assert(new UnloadCommandParser().parse(command) == Some(expected))
+  }
   
 }


### PR DESCRIPTION
The current usage of Redshift Fake Driver does not allow to test COPY and UNLOAD commands if the credentials are not provided as an API KEY.

This PR extends the credentials functionality to accept the 'iam_role' parameter. Tests have been added for the new code.