### PR TITLE
[opt-tech/redshift-fake-driver#74] Change UNLOAD command's CSV file suffix to match official AWS Redshift:

### DIFF
--- a/src/main/scala/jp/ne/opt/redshiftfake/write/Writer.scala
+++ b/src/main/scala/jp/ne/opt/redshiftfake/write/Writer.scala
@@ -30,7 +30,7 @@ class Writer(unloadCommand: UnloadCommand, s3Service: S3Service) {
       }
     }
     val result = stream.toString("UTF-8")
-    val resultKey = s"${unloadCommand.destination.prefix}0000_part_00"
+    val resultKey = s"${unloadCommand.destination.prefix}000"
 
     if (unloadCommand.createManifest) {
       val resultUrl = unloadCommand.destination.copy(prefix = resultKey).full


### PR DESCRIPTION
Actual AWS Redshift uses `000` as the CSV file suffix, which is different than the non-standard `0000_part_00` currently hardcoded in the `redshift-fake` driver.

This PR updates this suffix to `000` to match AWS's Redshift behaviour, as per the official AWS Redshift documentation: https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html